### PR TITLE
[WIP] Default values, template specialization approach

### DIFF
--- a/include/xproperty/xobserved.hpp
+++ b/include/xproperty/xobserved.hpp
@@ -86,6 +86,9 @@ namespace xp
         template <class P>
         void unvalidate();
 
+        template <class P>
+        static typename P::value_type default_value();
+
     protected:
 
         xobserved() = default;
@@ -178,6 +181,14 @@ namespace xp
     inline void xobserved<D>::unvalidate()
     {
         m_validators.erase(P::offset());
+    }
+
+    template <class D>
+    template <class P>
+    inline auto xobserved<D>::default_value() -> typename P::value_type
+    {
+        using value_type = typename P::value_type;
+        return value_type();
     }
 
     template <class D>

--- a/test/test_xproperty.cpp
+++ b/test/test_xproperty.cpp
@@ -54,6 +54,8 @@ TEST(xproperty, basic)
 
 struct Wrapper
 {
+    MAKE_OBSERVED()
+
     XPROPERTY(Foo, Wrapper, foo);
 };
 
@@ -66,5 +68,21 @@ TEST(xproperty, nested)
     ASSERT_EQ(1.0, double(wrapper.foo().bar));
     ASSERT_EQ(1, xp::get_observe_count());
     ASSERT_EQ(1, xp::get_validate_count());
+}
+
+struct Bat
+{
+    MAKE_OBSERVED()
+
+    XPROPERTY(double, Bat, man);
+};
+
+XDEFAULT_VALUE(Bat, man, 1.0)
+
+TEST(xproperty, default_values)
+{
+    Bat bat;
+
+    ASSERT_EQ(1.0, double(bat.man));
 }
 


### PR DESCRIPTION
Template specialization approach to default specialization.

**Overriding in derived classes**

Unlike in #12 , we can redefine the default value in derived classes.

**Main issues**

 - the template specialization of `owner::default_value<property_type>()` has to be done in the namespace scope, and not in class, so no hope for macros specifying the default value in XPROPERTY.
 - Since this has to be done outside of the owner class, this poses issues when the own is a template, since declaration then requires another `template <...>` line...