### PR TITLE
[WIP] Default values, property static method approach

### DIFF
--- a/include/xproperty/xobserved.hpp
+++ b/include/xproperty/xobserved.hpp
@@ -106,7 +106,7 @@ namespace xp
         friend class xproperty;
 
         template <class P>
-        void notify(const P& property) const;
+        void notify(const P&) const;
 
         template <class P>
         void invoke_observers() const;
@@ -182,7 +182,7 @@ namespace xp
 
     template <class D>
     template <class P>
-    inline void xobserved<D>::notify(const P& property) const
+    inline void xobserved<D>::notify(const P&) const
     {
     }
 

--- a/test/test_xobserved.cpp
+++ b/test/test_xobserved.cpp
@@ -25,7 +25,7 @@ TEST(xobserved, basic)
     xp::reset_counter();
     Observed foo;
 
-    XOBSERVE(foo, bar, [](const Observed& f) 
+    XOBSERVE(foo, bar, [](const Observed&) 
     {
         ++xp::get_observe_count();
     });

--- a/test/test_xproperty.cpp
+++ b/test/test_xproperty.cpp
@@ -54,6 +54,8 @@ TEST(xproperty, basic)
 
 struct Wrapper
 {
+    MAKE_OBSERVED()
+
     XPROPERTY(Foo, Wrapper, foo);
 };
 
@@ -66,5 +68,19 @@ TEST(xproperty, nested)
     ASSERT_EQ(1.0, double(wrapper.foo().bar));
     ASSERT_EQ(1, xp::get_observe_count());
     ASSERT_EQ(1, xp::get_validate_count());
+}
+
+struct Bat
+{
+    MAKE_OBSERVED()
+
+    XPROPERTY(double, Bat, man, 1.0);
+};
+
+TEST(xproperty, default_values)
+{
+    Bat bat;
+
+    ASSERT_EQ(1.0, double(bat.man));
 }
 


### PR DESCRIPTION
This approach enables

`XPROPERTY(TYPE, OWNER, NAME, VALUE)`

However, one cannot redefine the default value in the derived classes.