### PR TITLE
[WIP] Default values, tag dispatching approach

### DIFF
--- a/include/xproperty/xobserved.hpp
+++ b/include/xproperty/xobserved.hpp
@@ -86,6 +86,9 @@ namespace xp
         template <class P>
         void unvalidate();
 
+        template <class Tag>
+        static typename Tag::value_type default_value(Tag);
+
     protected:
 
         xobserved() = default;
@@ -106,7 +109,7 @@ namespace xp
         friend class xproperty;
 
         template <class P>
-        void notify(const P& property) const;
+        void notify(const P&) const;
 
         template <class P>
         void invoke_observers() const;
@@ -181,8 +184,16 @@ namespace xp
     }
 
     template <class D>
+    template <class Tag>
+    inline auto xobserved<D>::default_value(Tag) -> typename Tag::value_type
+    {
+        using value_type = typename Tag::value_type;
+        return value_type();
+    }
+
+    template <class D>
     template <class P>
-    inline void xobserved<D>::notify(const P& property) const
+    inline void xobserved<D>::notify(const P&) const
     {
     }
 

--- a/test/test_xobserved.cpp
+++ b/test/test_xobserved.cpp
@@ -25,7 +25,7 @@ TEST(xobserved, basic)
     xp::reset_counter();
     Observed foo;
 
-    XOBSERVE(foo, bar, [](const Observed& f) 
+    XOBSERVE(foo, bar, [](const Observed&) 
     {
         ++xp::get_observe_count();
     });

--- a/test/test_xproperty.cpp
+++ b/test/test_xproperty.cpp
@@ -54,6 +54,8 @@ TEST(xproperty, basic)
 
 struct Wrapper
 {
+    MAKE_OBSERVED()
+
     XPROPERTY(Foo, Wrapper, foo);
 };
 
@@ -66,5 +68,19 @@ TEST(xproperty, nested)
     ASSERT_EQ(1.0, double(wrapper.foo().bar));
     ASSERT_EQ(1, xp::get_observe_count());
     ASSERT_EQ(1, xp::get_validate_count());
+}
+
+struct Bat
+{
+    MAKE_OBSERVED()
+
+    XPROPERTY(double, Bat, man, 1.0);
+};
+
+TEST(xproperty, default_values)
+{
+    Bat bat;
+
+    ASSERT_EQ(1.0, double(bat.man));
 }
 


### PR DESCRIPTION
This is an alternative to #11, where instead of using template specialization, we use tag dispatching with an internal tag defined in properties.

The benefit is that since it uses method overloading instead of specialization, it can be done in the class scope (and not namespace scope), and therefore be combined in a single macro defining default values, and enabling the overriding in derived classes of the owner.

**Issues with this approach**

In order to perform the overriding in derived classes, we must access to the type of the tag in properties defined in bases.

Types in template bases are not accessible. Using approaches with `declval` of the owner to use `operator->` (to make them dependent names) make compilers complain about incomplete types.
