### PR TITLE
invoke_validators is now templated by value's type instead of propert…

### DIFF
--- a/include/xproperty/xobserved.hpp
+++ b/include/xproperty/xobserved.hpp
@@ -108,7 +108,7 @@ namespace xp
 
         void invoke_observers(const std::string&);
 
-        template <class P, class V>
+        template <class T, class V>
         auto invoke_validators(const std::string&, V&& r);
     };
 
@@ -193,10 +193,10 @@ namespace xp
     }
 
     template <class D>
-    template <class P, class V>
+    template <class T, class V>
     inline auto xobserved<D>::invoke_validators(const std::string& name, V&& v)
     {
-        using value_type = typename P::value_type;
+        using value_type = T;
         value_type value(std::forward<V>(v));
 
         auto position = m_validators.find(name);

--- a/include/xproperty/xproperty.hpp
+++ b/include/xproperty/xproperty.hpp
@@ -212,7 +212,7 @@ namespace xp
     template <class V>
     inline auto xproperty<T, O>::assign(V&& value) -> reference
     {
-        m_value = owner()->template invoke_validators<xproperty<T, O>>(m_name, std::forward<V>(value));
+        m_value = owner()->template invoke_validators<T>(m_name, std::forward<V>(value));
         owner()->notify(m_name, m_value);
         owner()->invoke_observers(m_name);
         return m_value;


### PR DESCRIPTION
…y's type
Similar to #44 but for `invoke_validators` method.